### PR TITLE
Add a -bfs option to the dux command for breadth-first-treewalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Usage: dux
         -threads <threads>      number of threads
         -limit <limit>  limit of files to list
         -verbose        print verbose output
+        -bfs            do a breadth first search of the path
         <path>
 ```
 

--- a/src/main/java/org/apache/hadoop/fs/store/CommonParameters.java
+++ b/src/main/java/org/apache/hadoop/fs/store/CommonParameters.java
@@ -52,6 +52,8 @@ public final class CommonParameters {
   /** {@value}. */
   public static final String THREADS = "threads";
 
+  public static final String BFS = "bfs";
+
   private CommonParameters() {
   }
 }

--- a/src/main/java/org/apache/hadoop/fs/store/commands/ExtendedDu.java
+++ b/src/main/java/org/apache/hadoop/fs/store/commands/ExtendedDu.java
@@ -27,8 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -94,7 +92,7 @@ public class ExtendedDu extends StoreEntryPoint {
 
   private int limit;
 
-  ExecutorService completion;
+  private ExecutorService completion;
 
   private Queue<Future<Summary>> queue;
 
@@ -155,7 +153,7 @@ public class ExtendedDu extends StoreEntryPoint {
         } else {
           // it's a dir
           submitted++;
-          if(!isBFS) {
+          if (!isBFS) {
             queue.add(completion.submit(() -> scanOneDir(out, st.getPath())));
           } else {
             queue.add(completion.submit(() -> scanOneDirBFS(out, st.getPath())));
@@ -167,7 +165,7 @@ public class ExtendedDu extends StoreEntryPoint {
       println("Waiting for %d scan to finish", submitted);
       while (!queue.isEmpty()) {
         Future<Summary> fts = queue.remove();
-        if(fts.isDone()){
+        if (fts.isDone()) {
           results.add(fts.get());
         } else {
           queue.add(fts);
@@ -253,7 +251,7 @@ public class ExtendedDu extends StoreEntryPoint {
         final FileStatus status = lister.next();
         long len = status.getLen();
         count ++;
-        if(!status.isFile()){
+        if (!status.isFile()) {
           printIfVerbose("Pushing path:", path.toString());
           queue.add(completion.submit(() -> scanOneDirBFS(out, status.getPath())));
           continue;

--- a/src/main/java/org/apache/hadoop/fs/store/commands/ExtendedDu.java
+++ b/src/main/java/org/apache/hadoop/fs/store/commands/ExtendedDu.java
@@ -245,16 +245,16 @@ public class ExtendedDu extends StoreEntryPoint {
   private Summary scanOneDirBFS(final PrintStream out, Path path) throws IOException {
     long size = 0;
     int count = 0;
-    RemoteIterator<LocatedFileStatus> lister = null;
+    RemoteIterator<FileStatus> lister = null;
     try (StoreDurationInfo duration = new StoreDurationInfo(out,
         "List %s", path)){
-      lister = fs.listFiles(path, true);
+      lister = fs.listStatusIterator(path);
       while (lister.hasNext()) {
-        final LocatedFileStatus status = lister.next();
+        final FileStatus status = lister.next();
         long len = status.getLen();
         count ++;
         if(!status.isFile()){
-          out.println("Pushing path:" + path.toString());
+          printIfVerbose("Pushing path:", path.toString());
           queue.add(completion.submit(() -> scanOneDirBFS(out, status.getPath())));
           continue;
         }

--- a/src/main/java/org/apache/hadoop/fs/store/commands/ExtendedDu.java
+++ b/src/main/java/org/apache/hadoop/fs/store/commands/ExtendedDu.java
@@ -26,8 +26,11 @@ import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorCompletionService;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -51,6 +54,7 @@ import org.apache.hadoop.fs.store.StoreEntryPoint;
 import org.apache.hadoop.util.ToolRunner;
 
 import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
+import static org.apache.hadoop.fs.store.CommonParameters.BFS;
 import static org.apache.hadoop.fs.store.CommonParameters.DEFINE;
 import static org.apache.hadoop.fs.store.CommonParameters.LIMIT;
 import static org.apache.hadoop.fs.store.CommonParameters.THREADS;
@@ -75,6 +79,7 @@ public class ExtendedDu extends StoreEntryPoint {
       + optusage(THREADS, "threads", "number of threads")
       + optusage(LIMIT, "limit", "limit of files to list")
       + optusage(VERBOSE, "print verbose output")
+      + optusage(BFS, "breadth first search of the tree", "do a deep breadth first search of the tree")
       + "\t<path>";
 
   public static final int DEFAULT_THREADS = 8;
@@ -89,9 +94,13 @@ public class ExtendedDu extends StoreEntryPoint {
 
   private int limit;
 
+  ExecutorService completion;
+
+  private Queue<Future<Summary>> queue;
+
   public ExtendedDu() {
     createCommandFormat(1, 1, VERBOSE);
-    addValueOptions(TOKENFILE, XMLFILE, DEFINE, THREADS, LIMIT);
+    addValueOptions(TOKENFILE, XMLFILE, DEFINE, THREADS, LIMIT, BFS);
   }
 
   @Override
@@ -108,6 +117,8 @@ public class ExtendedDu extends StoreEntryPoint {
     int threads = getOptional(THREADS).map(Integer::valueOf).orElse(
         DEFAULT_THREADS);
 
+    boolean isBFS = getOptional(BFS).isPresent();
+
     final Path source = new Path(paths.get(0));
     println("");
     heading("Listing files under %s with thread count %d",
@@ -122,13 +133,10 @@ public class ExtendedDu extends StoreEntryPoint {
     fs = source.getFileSystem(conf);
     limit = getOptional(LIMIT).map(Integer::valueOf).orElse(0);
     // worker pool
-    ExecutorService workers = new ThreadPoolExecutor(threads, threads,
+    completion = new ThreadPoolExecutor(threads, threads,
         0L, TimeUnit.MILLISECONDS,
         new LinkedBlockingQueue<>());
-
-    // now completion service for all outstanding workers
-    ExecutorCompletionService<Summary> completion
-        = new ExecutorCompletionService<>(workers);
+    queue = new LinkedBlockingQueue<>();
     List<Summary> results = new ArrayList<>();
 
 
@@ -147,16 +155,23 @@ public class ExtendedDu extends StoreEntryPoint {
         } else {
           // it's a dir
           submitted++;
-          completion.submit(() -> scanOneDir(out, st.getPath()));
+          if(!isBFS) {
+            queue.add(completion.submit(() -> scanOneDir(out, st.getPath())));
+          } else {
+            queue.add(completion.submit(() -> scanOneDirBFS(out, st.getPath())));
+          }
         }
       }
 
       // here we have all scans submitted
       println("Waiting for %d scan to finish", submitted);
-      while (submitted > 0) {
-        final Summary summary = completion.take().get();
-        results.add(summary);
-        submitted--;
+      while (!queue.isEmpty()) {
+        Future<Summary> fts = queue.remove();
+        if(fts.isDone()){
+          results.add(fts.get());
+        } else {
+          queue.add(fts);
+        }
       }
 
     } catch (LimitReachedException ex) {
@@ -181,8 +196,8 @@ public class ExtendedDu extends StoreEntryPoint {
     long bytesPerFile = (files > 0 ? totalSize / files : 0);
     println("");
     heading("Disk usage of %s", source);
-    println("Found %s files, %,.2f milliseconds per file",
-        files, millisPerFile);
+    println("Found %s files, time taken %,.2f, %,.2f milliseconds per file",
+        files, (float)duration.value(), millisPerFile);
     println("Data size %siB (%,d bytes)",
         long2String(totalSize, "", DECIMAL_PLACES), totalSize);
     println("Average file size %siB (%,d bytes)",
@@ -225,6 +240,42 @@ public class ExtendedDu extends StoreEntryPoint {
       sb.append('}');
       return sb.toString();
     }
+  }
+
+  private Summary scanOneDirBFS(final PrintStream out, Path path) throws IOException {
+    long size = 0;
+    int count = 0;
+    RemoteIterator<LocatedFileStatus> lister = null;
+    try (StoreDurationInfo duration = new StoreDurationInfo(out,
+        "List %s", path)){
+      lister = fs.listFiles(path, true);
+      while (lister.hasNext()) {
+        final LocatedFileStatus status = lister.next();
+        long len = status.getLen();
+        count ++;
+        if(!status.isFile()){
+          out.println("Pushing path:" + path.toString());
+          queue.add(completion.submit(() -> scanOneDirBFS(out, status.getPath())));
+          continue;
+        }
+        size += len;
+        updateValues(1, len);
+      }
+    } catch (InterruptedIOException | RejectedExecutionException interrupted) {
+      println("Interrupted");
+      LOG.debug("Interrupted", interrupted);
+    } catch (AccessDeniedException | PathAccessDeniedException denied) {
+      println("Access denied listing %s", path);
+    } catch (FileNotFoundException | LimitReachedException end) {
+      // path has been deleted; ignore
+    } finally {
+      if (lister != null) {
+        printIfVerbose("List iterator: %s", lister);
+        maybeClose(lister);
+      }
+    }
+    final Summary summary = new Summary(path, size, count);
+    return summary;
   }
 
   private Summary scanOneDir(final PrintStream out, Path path) throws IOException {


### PR DESCRIPTION

The `-bfs` option for dux does a breadth-first treewalk of the target filesystem, scanning subdirectories in parallel.

This is faster for high-latency object stores which don't have an O(1) deep tree list command (which S3 does; this option will be slower there)