### PR TITLE
enchance debugging with -debug and -logoverrides <file>

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ There are a set of arguments common to all commands
 -sysprops <file>        Java system properties to set
 -tokenfile <file>       Hadoop token file to load
 -verbose                Verbose output
+-debug                  Extra debug logs (JVM and Log4j overrides)
+-logoverrides <file>    A newline separated list of packages and classes for Log4j overrides
 -xmlfile <file>         XML config file to load
 ```
 

--- a/src/main/extra/org/apache/hadoop/fs/s3a/extra/ListMultiparts.java
+++ b/src/main/extra/org/apache/hadoop/fs/s3a/extra/ListMultiparts.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.tools.csv.SimpleCsvWriter;
 import org.apache.hadoop.util.ToolRunner;
 
 import static org.apache.hadoop.fs.store.CommonParameters.DEBUG;
-import static org.apache.hadoop.fs.store.CommonParameters.DEBUG_USAGE;
 import static org.apache.hadoop.fs.store.CommonParameters.DEFINE;
 import static org.apache.hadoop.fs.store.CommonParameters.LIMIT;
 import static org.apache.hadoop.fs.store.CommonParameters.STANDARD_OPTS;

--- a/src/main/extra/org/apache/hadoop/fs/s3a/extra/ListVersions.java
+++ b/src/main/extra/org/apache/hadoop/fs/s3a/extra/ListVersions.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.fs.store.StoreEntryPoint;
 import org.apache.hadoop.util.ToolRunner;
 
 import static org.apache.hadoop.fs.store.CommonParameters.DEBUG;
-import static org.apache.hadoop.fs.store.CommonParameters.DEBUG_USAGE;
 import static org.apache.hadoop.fs.store.CommonParameters.DEFINE;
 import static org.apache.hadoop.fs.store.CommonParameters.LIMIT;
 import static org.apache.hadoop.fs.store.CommonParameters.STANDARD_OPTS;

--- a/src/main/extra/org/apache/hadoop/fs/s3a/extra/Undelete.java
+++ b/src/main/extra/org/apache/hadoop/fs/s3a/extra/Undelete.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.util.ToolRunner;
 
 import static org.apache.hadoop.fs.s3a.extra.S3ListingSupport.isDirMarker;
 import static org.apache.hadoop.fs.store.CommonParameters.DEBUG;
-import static org.apache.hadoop.fs.store.CommonParameters.DEBUG_USAGE;
 import static org.apache.hadoop.fs.store.CommonParameters.DEFINE;
 import static org.apache.hadoop.fs.store.CommonParameters.LIMIT;
 import static org.apache.hadoop.fs.store.CommonParameters.STANDARD_OPTS;

--- a/src/main/java/org/apache/hadoop/fs/store/CommonParameters.java
+++ b/src/main/java/org/apache/hadoop/fs/store/CommonParameters.java
@@ -40,6 +40,12 @@ public final class CommonParameters {
   /** {@value}. */
   public static final String VERBOSE = "verbose";
 
+  /** {@value}. */
+  public static final String DEBUG = "debug";
+
+  /** {@value}. */
+  public static final String LOG_OVERRIDES = "logoverrides";
+
   /**
    * Standard options of all entry points.
    */
@@ -48,7 +54,10 @@ public final class CommonParameters {
           + optusage(SYSPROPS, "file", "Property file of system properties")
           + optusage(TOKENFILE, "file", "Hadoop token file to load")
           + optusage(XMLFILE, "file", "XML config file to load")
-          + optusage(VERBOSE, "verbose output");
+          + optusage(VERBOSE, "verbose output")
+          + optusage(DEBUG, "enable JVM logs (ALL) and override log4j levels (DEBUG) on specified packages or classes")
+          + optusage(LOG_OVERRIDES, "file", "A newline separated list of package and class names")
+          ;
 
   /**
    * File for log4j properties: {@value}.
@@ -67,9 +76,6 @@ public final class CommonParameters {
 
   public static final String CSVFILE = "csv";
 
-  public static final String DEBUG = "debug";
-
-  public static final String DEBUG_USAGE = "debug with extra logging";
   public static final String FLUSH = "flush";
 
   public static final String HFLUSH = "hflush";

--- a/src/main/java/org/apache/hadoop/fs/store/StoreEntryPoint.java
+++ b/src/main/java/org/apache/hadoop/fs/store/StoreEntryPoint.java
@@ -390,6 +390,7 @@ public class StoreEntryPoint extends Configured implements Tool, Closeable, Prin
         return stream
                 .map(String::trim)
                 .filter(line -> !line.startsWith("#"))
+                .filter(line -> !line.isEmpty())
                 .collect(Collectors.toList());
       } catch (IOException e) {
         println("could not read logoverrides file='%s' error='%s'", customLogLevelFile, e.getMessage());

--- a/src/main/java/org/apache/hadoop/fs/store/StoreEntryPoint.java
+++ b/src/main/java/org/apache/hadoop/fs/store/StoreEntryPoint.java
@@ -37,6 +37,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.LogManager;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -384,8 +386,11 @@ public class StoreEntryPoint extends Configured implements Tool, Closeable, Prin
   protected List<String> getLogOverrides() {
     String customLogLevelFile = getOption(LOG_OVERRIDES);
     if (customLogLevelFile != null) {
-      try {
-        return Files.readAllLines(Paths.get(customLogLevelFile));
+      try (Stream<String> stream = Files.lines(Paths.get(customLogLevelFile))) {
+        return stream
+                .map(String::trim)
+                .filter(line -> !line.startsWith("#"))
+                .collect(Collectors.toList());
       } catch (IOException e) {
         println("could not read logoverrides file='%s' error='%s'", customLogLevelFile, e.getMessage());
       }


### PR DESCRIPTION
# General

Be able to override `CLOUD_CONNECTOR_LOGS` at runtime. This can be useful when the configuration is on a read-only file system and the log4j configs needs to be overridden manually.

 - added the `-debug` option to the STANDARD_OPTS to fix the USAGE text
 - created a new option `-logoverrides` <file> to specify the packages/classes for the log level override
 - updated the README.md

# Tests

Usage example:
```
bash-5.2$ java -cp "$(printf %s: /opt/spark/jars/*.jar)":cloudstore-1.0.jar storediag
Usage: storediag [options] <filesystem>
	-D <key=value>	Define a single configuration option
	-sysprop <file>	Property file of system properties
	-tokenfile <file>	Hadoop token file to load
	-xmlfile <file>	XML config file to load
	-verbose	verbose output
	-debug	enable JVM logs (ALL) and override log4j levels (DEBUG) on specified packages or classes
	-logoverrides <file>	A newline separated list of package and class names
	-t	Require delegation tokens to be issued
	-e	List the environment variables. *danger: does not redact secrets*
	-h	redact all chars in sensitive options
	-j	List the JARs on the classpath
	-l	Dump the Log4J settings
	-5	Print MD5 checksums of the jars listed (requires -j)
	-o	Downgrade all 'required' classes to optional
	-principal <principal>	kerberos principal to request a token for
	-required <file>	text file of extra classes+resources to require
	-s	List the JVM System Properties
	-w	attempt write operations on the filesystem
```

```bash
bash-5.2$ cat logoverrides.txt
org.apache.hadoop.fs.s3a.S3AFileSystem
org.apache.knox.gateway.cloud.idbroker.s3a.IDBDelegationTokenBinding

bash-5.2$ java -cp "$(printf %s: /opt/spark/jars/*.jar)":cloudstore-1.0.jar storediag -debug -logoverrides logoverrides.txt s3a://a/b/c

...
15:39:18.028 [main] DEBUG org.apache.hadoop.fs.s3a.S3AFileSystem - S3GetFileStatus s3a://a/b/c
...

Success!
========
```